### PR TITLE
Link an article to an outside source

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
               <a>Speciály</a>
               <ul class="dropdown">
                 <li><a href="https://extra.demagog.cz/vladni-sliby/">Vládní sliby 2014—17</a></li>
-                <li><a href="https://extra.demagog.cz/sliby-milose-zemana/">Sliby Miloše Zemana</a></li>
+                <li><a href="https://zpravy.aktualne.cz/domaci/zverejnujeme-velkou-inventuru-zemanovych-slibu-ktere-slovo-d/r~9ebe8728ff6911e7adc2ac1f6b220ee8/">Sliby Miloše Zemana</a></li>
               </ul>
             </li>
 


### PR DESCRIPTION
Article is linked to an outside source as our version is not up to date.  Later we may transfer it back into the database (this will require variable veracity sets).

I'm creating a standalone PR as I may not finish my work on templates today.