### PR TITLE
Better meta tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "jbuilder", "~> 2.5"
 # Use friendly to generate slugs
 gem "friendly_id", "~> 5.1.0"
 
+# Use meta tags to add SEO tags to the head
+gem 'meta-tags'
+
 # Enables env. specific configuration
 gem "config"
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "jbuilder", "~> 2.5"
 gem "friendly_id", "~> 5.1.0"
 
 # Use meta tags to add SEO tags to the head
-gem 'meta-tags'
+gem "meta-tags"
 
 # Enables env. specific configuration
 gem "config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
     lumberjack (1.0.12)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
+    meta-tags (2.7.0)
+      actionpack (>= 3.2.0, < 5.3)
     method_source (0.9.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
@@ -331,6 +333,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   kaminari
   listen (>= 3.0.5, < 3.2)
+  meta-tags
   mysql2
   rack-cors
   rails (~> 5.1.4)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,29 +1,9 @@
 <!DOCTYPE html>
 <html lang="cs">
   <head>
-    <title>Demagog.cz &mdash; <%= content_for?(:title) ? yield(:title) : 'Factcheck politických diskuzí' %></title>
     <%= csrf_meta_tags %>
-
-    <meta name="author" content="Demagog.cz" >
-    <meta name="web_author" content="Demagog2 Dev Team — github.com/Demagog2">
-    <meta name="author" content="Demagog.cz" >
-    <meta name="description" content="Politici operují s informacemi, které jsou zkreslené, účelově vytrhávané z původních kontextů, neúplné anebo přímo lživé. Moderátor o tom často nevědí, protože jim chybějí informace a nedokážou efektivně a jednoznačně oponovat. Projekt Demagog.cz má za cíl kontrolu těchto tvrzení.">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#f04124"/>
-
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-
-    <link rel="shortcut icon" href="<%= asset_path("favicon.png") %>" type="image/x-icon" />
-    <!-- Add apple touch icon -->
-
-    <%# {#% stylesheets "static/bower_components/foundation/css/foundation.min.css" %}
-        <link rel="stylesheet" href="{{ asset_url }}" />
-    {% endstylesheets %#}
-    {% stylesheets "static/scss/frontend.scss" filter="compass" %}
-        <link rel="stylesheet" href="{{ asset_url }}" />
-    {% endstylesheets %} %>
-    <!--[if IE 8]><link rel="stylesheet" href="./static/css/ie8-grid-foundation-4.css" type="text/css" media="screen" ><![endif]-->
-    <%= render partial: "shared/og" %>
+    <%= render partial: "shared/meta" %>
   </head>
 
   <body>

--- a/app/views/shared/_meta.html.erb
+++ b/app/views/shared/_meta.html.erb
@@ -1,0 +1,32 @@
+<%= display_meta_tags site: 'Demagog.cz',
+  title: content_for?(:title) ? yield(:title) : 'Factcheck politických diskuzí',
+  separator: "&mdash;".html_safe,
+  description: (defined?(@article) and @article.perex.present?) ?
+    strip_tags(@article.perex).truncate(230) :
+    'Politici operují s informacemi, které jsou zkreslené, účelově vytrhávané z původních kontextů, neúplné anebo přímo lživé. Moderátor o tom často nevědí, protože jim chybějí informace a nedokážou efektivně a jednoznačně oponovat. Projekt Demagog.cz má za cíl kontrolu těchto tvrzení.',
+  keywords: %w[factcheck politics truth ověřování politika pravda],
+  author: 'Demagog.cz',
+  web_author: 'Demagog2 Dev Team — github.com/Demagog2',
+  viewport: 'width=device-width, initial-scale=1',
+  'theme-color': '#f04124',
+  charset: 'utf-8',
+  image_src: defined?(@article) ? 
+      article_illustration(@article.illustration, @article.article_type.name) : 
+      asset_path("apple-touch-icon.png"),
+  icon: [
+    { href: asset_path('favicon.png'), sizes: '64x64', type: 'image/png' },
+    { href: asset_path('apple-touch-icon.png'), rel: 'apple-touch-icon-precomposed', sizes: '114x114', type: 'image/png' },
+  ],
+  og: {
+    title: :title,
+    site_name: :site,
+    type: 'article',
+    url: url_for(:only_path => false),
+    image: :image_src,
+    author: :author
+  },
+  twitter: {
+    card: 'summary',
+    site: '@DemagogCZ'
+  }
+%>

--- a/app/views/shared/_og.html.erb
+++ b/app/views/shared/_og.html.erb
@@ -1,5 +1,0 @@
-<meta property="og:url" content="<%= url_for(:only_path => false) %>" />
-<meta property="og:type" content="article" />
-<meta property="og:title" content="<%= content_for?(:title) ? yield(:title) : 'Factcheck politických diskuzí' %>" />
-<meta property="og:description" content="<%= defined?(@article) and @article.perex.present? ? strip_tags(@article.perex).truncate(230) : 'Politici operují s informacemi, které jsou zkreslené, účelově vytrhávané z původních kontextů, neúplné anebo přímo lživé. Moderátor o tom často nevědí, protože jim chybějí informace a nedokážou efektivně a jednoznačně oponovat. Projekt Demagog.cz má za cíl kontrolu těchto tvrzení.'%>" />
-<meta property="og:image" content="<%= defined?(@article) ? article_illustration(@article.illustration, @article.article_type.name) : asset_path("apple-touch-icon.png") %>" />


### PR DESCRIPTION
Meta tags are now centralized and generated via https://github.com/kpumuk/meta-tags gem. Open graph and twitter card info is included.