### PR TITLE
Fixing og meta tags

### DIFF
--- a/app/views/shared/_meta.html.erb
+++ b/app/views/shared/_meta.html.erb
@@ -23,6 +23,7 @@
   og: {
     title: :title,
     site_name: :site,
+    description: :description,
     type: 'article',
     url: url_for(:only_path => false),
     image: :image_src,


### PR DESCRIPTION
I checked the twitter card validator and it did not get description and image. I added `og:description` that was missing and added issue #60 that covers possible problem with invalid URLs because of non-url_encoded chars in migrated assets' filenames.

If the url_encode is easy, you may merge it into this PR.