### PR TITLE
Remove login success message

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,7 +5,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user && @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", kind: "Google"
       sign_in_and_redirect @user, event: :authentication, after_sign_in_path_for: admin_path
     else
       flash[:alert] = I18n.t "devise.omniauth_callbacks.failure", kind: "Google", reason: "User not found"


### PR DESCRIPTION
We don't need the message, user sees the success by seeing the admin UI and the message only takes up space till user reloads the page.