### PR TITLE
Add users to about us page

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -3,6 +3,6 @@
 class PageController < ApplicationController
   def show
     @page = Page.published.friendly.find(params[:slug])
-    @users = User.where(active: true).order(rank: :asc, last_name: :asc) if params[:slug] == "o-nas"
+    @users = User.where(active: true, user_public: true).order(rank: :asc, last_name: :asc) if params[:slug] == "o-nas"
   end
 end

--- a/app/graphql/mutations/update_user_publicity.rb
+++ b/app/graphql/mutations/update_user_publicity.rb
@@ -12,6 +12,6 @@ Mutations::UpdateUserPublicity = GraphQL::Field.define do
     Utils::Auth.authenticate(ctx)
     Utils::Auth.authorize(ctx, ["users:edit-user-public"])
 
-    User.update(args[:id], user_public: args[:user_public].to_b)
+    User.update(args[:id], user_public: args[:user_public])
   }
 end

--- a/app/graphql/mutations/update_user_publicity.rb
+++ b/app/graphql/mutations/update_user_publicity.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Mutations::UpdateUserPublicity = GraphQL::Field.define do
+  name "UpdateUserPublicity"
+  type Types::UserType
+  description "Update user publicity"
+
+  argument :id, !types.Int
+  argument :user_public, !types.Boolean
+
+  resolve -> (obj, args, ctx) {
+    Utils::Auth.authenticate(ctx)
+    Utils::Auth.authorize(ctx, ["users:edit-user-public"])
+
+    User.update(args[:id], user_public: args[:user_public].to_b)
+  }
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -13,6 +13,7 @@ Types::MutationType = GraphQL::ObjectType.define do
 
   field :createUser, Mutations::CreateUser
   field :updateUser, Mutations::UpdateUser
+  field :updateUserPublicity, Mutations::UpdateUserPublicity
   field :deleteUser, Mutations::DeleteUser
 
   field :createMedium, Mutations::CreateMedium

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -17,6 +17,7 @@ Types::UserType = GraphQL::ObjectType.define do
   field :rang, types.Int
   field :role, !Types::RoleType
   field :email_notifications, !types.Boolean
+  field :user_public, !types.Boolean
 
   field :created_at, !types.String
   field :updated_at, types.String

--- a/app/javascript/admin/components/Users.tsx
+++ b/app/javascript/admin/components/Users.tsx
@@ -6,7 +6,7 @@ import { Button, Callout, Card, Classes, Colors, Switch } from '@blueprintjs/cor
 import { IconNames } from '@blueprintjs/icons';
 import { ApolloError } from 'apollo-client';
 import * as classNames from 'classnames';
-import { Query, Mutation } from 'react-apollo';
+import { Mutation, Query } from 'react-apollo';
 import { connect, Dispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 

--- a/app/javascript/admin/components/Users.tsx
+++ b/app/javascript/admin/components/Users.tsx
@@ -6,7 +6,7 @@ import { Button, Callout, Card, Classes, Colors, Switch } from '@blueprintjs/cor
 import { IconNames } from '@blueprintjs/icons';
 import { ApolloError } from 'apollo-client';
 import * as classNames from 'classnames';
-import { Query } from 'react-apollo';
+import { Query, Mutation } from 'react-apollo';
 import { connect, Dispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 
@@ -15,7 +15,7 @@ import {
   GetUsersQuery as GetUsersQueryData,
   GetUsersQueryVariables,
 } from '../operation-result-types';
-import { DeleteUser } from '../queries/mutations';
+import { DeleteUser, UpdateUserPublicity } from '../queries/mutations';
 import { GetUsers } from '../queries/queries';
 import { newlinesToBr } from '../utils';
 import Authorize from './Authorize';
@@ -169,7 +169,14 @@ class Users extends React.Component<IProps, IUsersState> {
                       </div>
                       <div style={{ flex: '1 1', marginLeft: 15 }}>
                         <Authorize permissions={['users:edit']}>
-                          <div style={{ float: 'right', display: 'flex' }}>
+                          <div
+                            style={{
+                              float: 'right',
+                              display: 'flex',
+                              flexDirection: 'row',
+                              alignItems: 'center',
+                            }}
+                          >
                             <Link
                               to={`/admin/users/edit/${user.id}`}
                               className={classNames(
@@ -194,6 +201,53 @@ class Users extends React.Component<IProps, IUsersState> {
                                 text="Aktivovat"
                               />
                             )}
+                            <Authorize permissions={['users:edit-user-public']}>
+                              <Mutation
+                                mutation={UpdateUserPublicity}
+                                onCompleted={() =>
+                                  this.props.dispatch(
+                                    addFlashMessage(
+                                      'Viditelnost uživatele na stránce "O nás" byla upravena',
+                                      'success',
+                                    ),
+                                  )
+                                }
+                                onError={() =>
+                                  this.props.dispatch(
+                                    addFlashMessage(
+                                      'Došlo k chybě při ukládaní změny viditelnosti',
+                                      'error',
+                                    ),
+                                  )
+                                }
+                              >
+                                {(updateUserPublicity) =>
+                                  user.user_public ? (
+                                    <Button
+                                      icon={IconNames.EYE_OFF}
+                                      style={{ marginLeft: 7 }}
+                                      text="Skrýt v O nás"
+                                      onClick={() =>
+                                        updateUserPublicity({
+                                          variables: { id: Number(user.id), userPublicity: false },
+                                        })
+                                      }
+                                    />
+                                  ) : (
+                                    <Button
+                                      icon={IconNames.EYE_ON}
+                                      style={{ marginLeft: 7 }}
+                                      text="Zobrazit v O nás"
+                                      onClick={() =>
+                                        updateUserPublicity({
+                                          variables: { id: Number(user.id), userPublicity: true },
+                                        })
+                                      }
+                                    />
+                                  )
+                                }
+                              </Mutation>
+                            </Authorize>
                             <Button
                               type="button"
                               icon={IconNames.TRASH}
@@ -220,6 +274,11 @@ class Users extends React.Component<IProps, IUsersState> {
                           <br />
                           <span className={Classes.TEXT_MUTED}>Posílat upozornění emailem: </span>
                           {user.email_notifications ? 'Ano' : 'Ne'}
+                          <Authorize permissions={['users:edit-user-public']}>
+                            <br />
+                            <span className={Classes.TEXT_MUTED}>Zobrazit v O nás:&nbsp;</span>
+                            {user.user_public ? 'Ano' : 'Ne'}
+                          </Authorize>
                         </Callout>
                       </div>
                     </div>

--- a/app/javascript/admin/operation-result-types.ts
+++ b/app/javascript/admin/operation-result-types.ts
@@ -456,6 +456,7 @@ export interface CreateUserMutation {
     position_description: string | null,
     bio: string | null,
     email_notifications: boolean,
+    user_public: boolean,
     role:  {
       id: string,
       name: string,
@@ -480,6 +481,32 @@ export interface UpdateUserMutation {
     position_description: string | null,
     bio: string | null,
     email_notifications: boolean,
+    user_public: boolean,
+    role:  {
+      id: string,
+      name: string,
+    },
+  } | null,
+};
+
+export interface UpdateUserPublicityMutationVariables {
+  id: number,
+  userPublicity: boolean,
+};
+
+export interface UpdateUserPublicityMutation {
+  // Update user publicity
+  updateUserPublicity:  {
+    id: string,
+    first_name: string,
+    last_name: string,
+    email: string,
+    avatar: string | null,
+    active: boolean,
+    position_description: string | null,
+    bio: string | null,
+    email_notifications: boolean,
+    user_public: boolean,
     role:  {
       id: string,
       name: string,
@@ -863,6 +890,7 @@ export interface GetUsersQuery {
     bio: string | null,
     position_description: string | null,
     email_notifications: boolean,
+    user_public: boolean,
     role:  {
       id: string,
       name: string,
@@ -885,6 +913,7 @@ export interface GetUserQuery {
     bio: string | null,
     position_description: string | null,
     email_notifications: boolean,
+    user_public: boolean,
     role:  {
       id: string,
       name: string,

--- a/app/javascript/admin/queries/mutations.ts
+++ b/app/javascript/admin/queries/mutations.ts
@@ -250,6 +250,7 @@ export const CreateUser = gql`
       position_description
       bio
       email_notifications
+      user_public
       role {
         id
         name
@@ -270,6 +271,28 @@ export const UpdateUser = gql`
       position_description
       bio
       email_notifications
+      user_public
+      role {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UpdateUserPublicity = gql`
+  mutation UpdateUserPublicity($id: Int!, $userPublicity: Boolean!) {
+    updateUserPublicity(id: $id, user_public: $userPublicity) {
+      id
+      first_name
+      last_name
+      email
+      avatar
+      active
+      position_description
+      bio
+      email_notifications
+      user_public
       role {
         id
         name

--- a/app/javascript/admin/queries/queries.ts
+++ b/app/javascript/admin/queries/queries.ts
@@ -226,6 +226,7 @@ export const GetUsers = gql`
       bio
       position_description
       email_notifications
+      user_public
       role {
         id
         name
@@ -246,6 +247,7 @@ export const GetUser = gql`
       bio
       position_description
       email_notifications
+      user_public
       role {
         id
         name

--- a/app/javascript/admin/schema.json
+++ b/app/javascript/admin/schema.json
@@ -2968,6 +2968,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "user_public",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -5456,6 +5472,47 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "UserInputType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateUserPublicity",
+              "description": "Update user publicity",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "user_public",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
                       "ofType": null
                     }
                   },

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -41,6 +41,7 @@ EXPERT_PERMISSIONS = [
 
   "users:view",
   "users:edit",
+  "users:edit-user-public",
 
   "visualizations:view",
 ]

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -1,9 +1,7 @@
 <% content_for(:title, @page.title) %>
 
-<article class="full-text">
-  <h1><%= @page.title %></h1>
-
-  <section class="segment">
-    <%= raw(@page.text_html) %>
-  </section>
-</article>
+<% if @page.template == 'about_us' %>
+  <%= render('page/templates/about_us', page: @page) %>
+<% else %>
+  <%= render('page/templates/default', page: @page) %>
+<% end %>

--- a/app/views/page/templates/_about_us.html.erb
+++ b/app/views/page/templates/_about_us.html.erb
@@ -1,0 +1,9 @@
+<article class="full-text">
+  <h1><%= @page.title %></h1>
+
+  <section class="segment">
+    <%= raw(@page.text_html) %>
+  </section>
+
+  <%= render('shared/authors') %>
+</article>

--- a/app/views/page/templates/_default.html.erb
+++ b/app/views/page/templates/_default.html.erb
@@ -1,0 +1,7 @@
+<article class="full-text">
+  <h1><%= @page.title %></h1>
+
+  <section class="segment">
+    <%= raw(@page.text_html) %>
+  </section>
+</article>

--- a/db/migrate/20180826075824_add_user_public_to_users_table.rb
+++ b/db/migrate/20180826075824_add_user_public_to_users_table.rb
@@ -1,0 +1,5 @@
+class AddUserPublicToUsersTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :user_public, :boolean, nullable: false, default: false
+  end
+end

--- a/db/migrate/20180830075247_add_template_column_to_pages.rb
+++ b/db/migrate/20180830075247_add_template_column_to_pages.rb
@@ -1,0 +1,5 @@
+class AddTemplateColumnToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :template, :string
+  end
+end

--- a/db/migrate/20180830081830_set_template_to_about_us_page.rb
+++ b/db/migrate/20180830081830_set_template_to_about_us_page.rb
@@ -1,0 +1,10 @@
+class SetTemplateToAboutUsPage < ActiveRecord::Migration[5.2]
+  def up
+    page = Page.find_by(slug: "o-nas")
+    if page
+      page.template = "about_us"
+      page.save!
+      say "Page `about-us` template was updated"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_205322) do
+ActiveRecord::Schema.define(version: 2018_08_26_075824) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_205322) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.boolean "email_notifications", default: false
+    t.boolean "user_public", default: false
   end
 
   create_table "users_roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_26_075824) do
+ActiveRecord::Schema.define(version: 2018_08_30_081830) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 2018_08_26_075824) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "template"
   end
 
   create_table "roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
1. Users have new `user_public` attribute
2. Users with `user_public = true` will be shown on about us page
3. Users with role expert and higher can edit `user_public`
4. Special template for about us page was added

Closes #153