### PR TITLE
demagog on docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore editor files
+/.idea
+/.vscode
+
+# Ignore temporary files
+/log/*
+/tmp/*
+/storage/*
+/public/packs
+
+# Ignore dependencies
+/node_modules

--- a/.env.webpacker
+++ b/.env.webpacker
@@ -1,0 +1,3 @@
+NODE_ENV=development
+RAILS_ENV=development
+WEBPACKER_DEV_SERVER_HOST=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ruby:2.5.3-slim
+MAINTAINER Vaclav Bohac <bohac.v@gmail.com>
+
+RUN apt-get -y update && \
+      apt-get install --fix-missing --no-install-recommends -qq -y \
+        build-essential \
+        curl gnupg \
+        git-all \
+        default-libmysqlclient-dev && \
+      curl -sL https://deb.nodesource.com/setup_10.x | bash -  && \
+      apt-get update  && \
+      apt-get install -y nodejs && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /app
+
+RUN gem install bundler
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN bundle install
+
+COPY package.json .
+COPY yarn.lock .
+
+RUN npm install -g yarn
+RUN yarn install
+
+COPY . .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Political fact checking website. For more information see http://demagog.cz/o-na
 
 ## Setup
 
-Demagog can be run, tested and developed fully in the docker environment
+Demagog can be run, tested and fully developed in the [docker](https://www.docker.com/) environment
 
 ## First run
 ```
@@ -24,7 +24,7 @@ docker-compose exec web rails db:create db:migrate db:seed
 ## Running tests
 ```
 docker-compose exec web rails test
-docker-compose exec web yarn test
+docker-compose exec web yarn jest
 ```
 
 ## Rebuilding single service
@@ -76,10 +76,7 @@ Run guard-livereload server with `guard`.
 ## Generating Apollo flow types
 
 ```sh
-npm install -g apollo-codegen
-bin/rails server
-apollo-codegen introspect-schema http://localhost:3000/graphql --output schema.json
-apollo-codegen generate **/*.tsx --schema schema.json --target typescript --output operation-result-types.ts
+docker-compose exec web rails apollo:types
 ```
 
 ### Services (job queues, cache servers, search engines, etc.)
@@ -92,15 +89,6 @@ It's used to cache:
 
 * speaker statistics
 * speaker statistics for debate (article)
-
-### Migration from legacy DB
-
-```sh
-RAILS_ENV=migration bin/rails db:drop db:create db:migrate migration:run
-```
-
-To suppress output of `migration:run` rake task, run it with rake argument like this:
-`migration:run['quiet']`
 
 ### Deployment instructions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,33 @@ Political fact checking website. For more information see http://demagog.cz/o-na
 
 ### Ruby version
 
-2.5.1
+2.5.3
+
+## Setup
+
+Demagog can be run, tested and developed fully in the docker environment
+
+## First run
+```
+docker-compose build
+docker-compose up
+```
+
+## Setting up database
+```
+docker-compose exec web rails db:create db:migrate db:seed
+```
+
+## Running tests
+```
+docker-compose exec web rails test
+docker-compose exec web yarn test
+```
+
+## Rebuilding single service
+```
+docker-compose up -d --no-deps --build <service_name>
+```
 
 ## Configuration
 
@@ -66,13 +92,6 @@ It's used to cache:
 
 * speaker statistics
 * speaker statistics for debate (article)
-
-Assuming we use docker for
-```sh
-docker pull redis:alpine
-
-docker run --name redis -p 6379:6379 -d redis
-```
 
 ### Migration from legacy DB
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -31,7 +31,7 @@ default: &default
 
 development:
   <<: *default
-  compile: true
+  compile: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,14 @@ services:
     restart: always
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - db-data-volume:/var/lib/mysql
 
   webpacker:
     image: ${DOCKER_IMAGE_NAME-demagog}
     command: ["bin/webpack-dev-server"]
     volumes:
-      - .:/opt/demagog:cached
+      - .:/app:cached
     ports:
       - 3035:3035
 
@@ -36,4 +38,7 @@ services:
       - 3000:3000
     command: bundle exec rails s -b 0.0.0.0
     volumes:
-      - .:/opt/demagog:cached
+      - .:/app:cached
+
+volumes:
+    db-data-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,13 @@ services:
       - 6379:6379
     restart: always
 
+  elasticsearch:
+    image: elasticsearch:6.4.1
+    ports:
+      - 9200:9200
+      - 9300:9300
+    restart: always
+
   db:
     image: mysql:5.7.23
     ports:
@@ -34,6 +41,7 @@ services:
       - db
       - webpacker
       - redis
+      - elasticsearch
     ports:
       - 3000:3000
     command: bundle exec rails s -b 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.0'
+services:
+  db:
+    image: mysql:5.7.23
+    ports:
+      - 3306:3306
+    restart: always
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+
+  webpacker:
+    image: ${DOCKER_IMAGE_NAME-demagog}
+    command: ["bin/webpack-dev-server"]
+    volumes:
+      - .:/opt/demagog:cached
+    ports:
+      - 3035:3035
+
+  web:
+    image: ${DOCKER_IMAGE_NAME-demagog}
+    build:
+      context: .
+      args:
+        precompileassets: 'not'
+    links:
+      - db
+      - webpacker
+    ports:
+      - 3000:3000
+    command: bundle exec rails s -b 0.0.0.0
+    volumes:
+      - .:/opt/demagog:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 version: '3.0'
 services:
+  redis:
+    image: redis:5.0.0
+    ports:
+      - 6379:6379
+    restart: always
+
   db:
     image: mysql:5.7.23
     ports:
@@ -25,6 +31,7 @@ services:
     links:
       - db
       - webpacker
+      - redis
     ports:
       - 3000:3000
     command: bundle exec rails s -b 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,11 @@ services:
   webpacker:
     image: ${DOCKER_IMAGE_NAME-demagog}
     command: ["bin/webpack-dev-server"]
+    env_file:
+      - .env.webpacker
     volumes:
-      - .:/app:cached
+      - ./app:/app/app
+      - ./public:/app/public
     ports:
       - 3035:3035
 
@@ -39,14 +42,19 @@ services:
         precompileassets: 'not'
     links:
       - db
-      - webpacker
       - redis
       - elasticsearch
+      - webpacker
     ports:
       - 3000:3000
+    environment:
+      DB_HOST: db
+      WEBPACKER_DEV_SERVER_HOST: webpacker
+
     command: bundle exec rails s -b 0.0.0.0
     volumes:
-      - .:/app:cached
+      - ./app:/app/app
+      - ./public:/app/public
 
 volumes:
     db-data-volume:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/139369/47452258-13c76380-d7ca-11e8-8415-e06943cc8847.png)

Goal of this issue is to allow *development in dockerized environment* with the following goals:
* Necessary services should be isolated from other projects
  * That way we'll be prevented from clashing with other projects e.g. colliding versions of ruby, npm, yarn, mysql, redis, elasticsearch, etc
* The development should be OS agnostic
   * It should be possible to develop in Windows, Linux distros, macOS all the same
* Updating of ruby & node should be done easily

TODOs:
* [x] add redis service
* [x] add elasticsearch service
* [x] make sure webpacker service is being used
* [x] update instructions in README.md
* [x] add docker ignore – prevent copying local node_modules, storage, tmp files