### PR TITLE
Article segments cleanup

### DIFF
--- a/app/graphql/types/article_input_type.rb
+++ b/app/graphql/types/article_input_type.rb
@@ -9,6 +9,6 @@ Types::ArticleInputType = GraphQL::InputObjectType.define do
   argument :slug, types.String
   argument :published, types.Boolean
   argument :published_at, types.String
-  argument :segments, types[!Types::SegmentInputType]
+  argument :segments, types[!Types::ArticleSegmentInputType]
   argument :source_id, types.ID
 end

--- a/app/graphql/types/article_segment_input_type.rb
+++ b/app/graphql/types/article_segment_input_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-Types::SegmentInputType = GraphQL::InputObjectType.define do
-  name "SegmentInputType"
+Types::ArticleSegmentInputType = GraphQL::InputObjectType.define do
+  name "ArticleSegmentInputType"
 
   argument :id, types.ID
   argument :segment_type, !types.String

--- a/app/graphql/types/article_segment_type.rb
+++ b/app/graphql/types/article_segment_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-Types::SegmentType = GraphQL::ObjectType.define do
-  name "Segment"
+Types::ArticleSegmentType = GraphQL::ObjectType.define do
+  name "ArticleSegment"
 
   field :id, !types.ID
   field :segment_type, !types.String

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -55,9 +55,9 @@ Types::ArticleType = GraphQL::ObjectType.define do
     end
   end
 
-  field :segments, types[!Types::SegmentType] do
+  field :segments, types[!Types::ArticleSegmentType] do
     resolve -> (obj, args, ctx) do
-      obj.segments
+      obj.segments.ordered
     end
   end
 end

--- a/app/javascript/admin/operation-result-types.ts
+++ b/app/javascript/admin/operation-result-types.ts
@@ -24,11 +24,11 @@ export interface ArticleInputType {
   slug?: string | null,
   published?: boolean | null,
   published_at?: string | null,
-  segments?: Array< SegmentInputType > | null,
+  segments?: Array< ArticleSegmentInputType > | null,
   source_id?: string | null,
 };
 
-export interface SegmentInputType {
+export interface ArticleSegmentInputType {
   id?: string | null,
   segment_type: string,
   text_html?: string | null,

--- a/app/javascript/admin/schema.json
+++ b/app/javascript/admin/schema.json
@@ -3915,7 +3915,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "Segment",
+                    "name": "ArticleSegment",
                     "ofType": null
                   }
                 }
@@ -4071,7 +4071,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Segment",
+          "name": "ArticleSegment",
           "description": null,
           "fields": [
             {
@@ -6806,7 +6806,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
-                    "name": "SegmentInputType",
+                    "name": "ArticleSegmentInputType",
                     "ofType": null
                   }
                 }
@@ -6830,7 +6830,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SegmentInputType",
+          "name": "ArticleSegmentInputType",
           "description": null,
           "fields": null,
           "inputFields": [

--- a/app/models/article_segment.rb
+++ b/app/models/article_segment.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
-class Segment < ApplicationRecord
+class ArticleSegment < ApplicationRecord
   TYPE_TEXT = "text"
   TYPE_SOURCE_STATEMENTS = "source_statements"
 
   belongs_to :source, optional: true
   belongs_to :article, optional: true
 
+  scope :ordered, -> {
+    order(order: :asc)
+  }
+
   scope :source_statements_type_only, -> {
-    where(segment_type: Segment::TYPE_SOURCE_STATEMENTS)
+    where(segment_type: ArticleSegment::TYPE_SOURCE_STATEMENTS)
   }
 
   def is_text?
-    segment_type == Segment::TYPE_TEXT
+    segment_type == ArticleSegment::TYPE_TEXT
   end
 
   def is_source_statements?
-    segment_type == Segment::TYPE_SOURCE_STATEMENTS
+    segment_type == ArticleSegment::TYPE_SOURCE_STATEMENTS
   end
 
   def all_published_statements

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -3,7 +3,7 @@
 class Source < ApplicationRecord
   include Discardable
 
-  has_many :segments
+  has_many :article_segments
   has_many :statements
   has_many :statement_transcript_positions
   has_and_belongs_to_many :speakers

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -115,7 +115,7 @@ class Statement < ApplicationRecord
   end
 
   def mentioning_articles
-    Article.joins(:segments).where(segments: { source_id: source.id }).distinct.order(published_at: :desc)
+    Article.joins(:segments).where(article_segments: { source_id: source.id }).distinct.order(published_at: :desc)
   end
 
   private

--- a/db/migrate/20190303182849_segments_cleanup.rb
+++ b/db/migrate/20190303182849_segments_cleanup.rb
@@ -1,0 +1,9 @@
+class SegmentsCleanup < ActiveRecord::Migration[5.2]
+  def change
+    # Because we are not using it anymore
+    drop_table :article_has_segments
+
+    # Helps navigating in the database, name "segment" is too general
+    rename_table :segments, :article_segments
+  end
+end

--- a/db/migrate/20190303191709_remove_segments_without_article_id.rb
+++ b/db/migrate/20190303191709_remove_segments_without_article_id.rb
@@ -1,0 +1,5 @@
+class RemoveSegmentsWithoutArticleId < ActiveRecord::Migration[5.2]
+  def change
+    execute "DELETE FROM article_segments WHERE article_id IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_02_184817) do
+ActiveRecord::Schema.define(version: 2019_03_03_191709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,14 +37,16 @@ ActiveRecord::Schema.define(version: 2019_03_02_184817) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "article_has_segments", force: :cascade do |t|
-    t.integer "order"
-    t.bigint "article_id"
-    t.bigint "segment_id"
+  create_table "article_segments", force: :cascade do |t|
+    t.string "segment_type"
+    t.text "text_html"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["article_id"], name: "index_article_has_segments_on_article_id"
-    t.index ["segment_id"], name: "index_article_has_segments_on_segment_id"
+    t.text "text_slatejson"
+    t.bigint "source_id"
+    t.bigint "article_id"
+    t.integer "order"
+    t.index ["article_id"], name: "index_article_segments_on_article_id"
   end
 
   create_table "article_types", force: :cascade do |t|
@@ -221,18 +223,6 @@ ActiveRecord::Schema.define(version: 2019_03_02_184817) do
     t.string "name"
   end
 
-  create_table "segments", force: :cascade do |t|
-    t.string "segment_type"
-    t.text "text_html"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "text_slatejson"
-    t.bigint "source_id"
-    t.bigint "article_id"
-    t.integer "order"
-    t.index ["article_id"], name: "index_segments_on_article_id"
-  end
-
   create_table "sources", force: :cascade do |t|
     t.text "transcript"
     t.string "source_url"
@@ -345,5 +335,5 @@ ActiveRecord::Schema.define(version: 2019_03_02_184817) do
     t.string "key"
   end
 
-  add_foreign_key "segments", "articles"
+  add_foreign_key "article_segments", "articles"
 end

--- a/test/factories/model_fatory.rb
+++ b/test/factories/model_fatory.rb
@@ -42,12 +42,12 @@ FactoryBot.define do
     end
   end
 
-  factory :segment do
-    factory :segment_text do
+  factory :article_segment do
+    factory :article_segment_text do
       segment_type "text"
     end
 
-    factory :segment_source_statements do
+    factory :article_segment_source_statements do
       segment_type "source_statements"
     end
   end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -33,16 +33,18 @@ class ArticleTest < ActiveSupport::TestCase
     assert_changes -> { Article.count }, "Expected article to be created" do
       article = Article.create_article article_input
 
-      assert_equal 2, article.segments.size
+      assert_equal 2, article.segments.ordered.size
 
-      segment = article.segments.first
+      segment = article.segments.ordered.first
       assert_equal "text", segment.segment_type
       assert_equal "<p>Lorem ipsum...</p>", segment.text_html
+      assert_equal 0, segment.order
 
-      segment = article.segments.second
+      segment = article.segments.ordered.second
       assert_equal "source_statements", segment.segment_type
       assert_equal @source.id, segment.source.id
       assert_equal @statements.size, segment.all_published_statements.size
+      assert_equal 1, segment.order
     end
   end
 
@@ -68,16 +70,34 @@ class ArticleTest < ActiveSupport::TestCase
     assert_changes -> { Article.find(original_article.id).title }, "Expected article to be updated" do
       article = Article.update_article original_article.id, article_input
 
-      assert_equal 2, article.segments.size
+      assert_equal 2, article.segments.ordered.size
 
-      segment = article.segments.first
+      segment = article.segments.ordered.first
       assert_equal "text", segment.segment_type
       assert_equal "<p>Lorem ipsum...</p>", segment.text_html
+      assert_equal 0, segment.order
 
-      segment = article.segments.second
+      segment = article.segments.ordered.second
       assert_equal "source_statements", segment.segment_type
       assert_equal @source.id, segment.source.id
       assert_equal @statements.size, segment.all_published_statements.size
+      assert_equal 1, segment.order
     end
+  end
+
+  test "removed segment in update_article should be removed and not left without article_id in db" do
+    article = create(:article, article_type: @article_type)
+    article_segment = create(:article_segment_text, text_html: "<p>Yo</p>", article: article)
+
+    article_input = {
+      title: "My article",
+      perex: "Lorem ipsum sit dolor del amet...",
+      article_type: "default",
+      segments: []
+    }
+
+    Article.update_article article.id, article_input
+
+    assert_nil ArticleSegment.find_by id: article_segment.id
   end
 end

--- a/test/services/stats/article/stats_builder_test.rb
+++ b/test/services/stats/article/stats_builder_test.rb
@@ -47,7 +47,7 @@ class ArticleStatsBuilderTest < ActiveSupport::TestCase
     end
 
     def get_article(source)
-      segment = create(:segment_source_statements, source: source)
+      segment = create(:article_segment_source_statements, source: source)
 
       create(:fact_check, segments: [segment])
     end


### PR DESCRIPTION
* Remove now unused `article_has_segments` table
* Rename `segments` to `article_segments` as just "segment" is too general imho
* Fix filling segment order on article creation
* Fix removed segments being left without article_id rather than actually removed