### PR TITLE
Graphl updates

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -185,6 +185,17 @@ Types::QueryType = GraphQL::ObjectType.define do
       statements = statements.where(speaker: args[:speaker]) if args[:speaker]
       statements = statements.joins(:veracities).where(veracities: { key: args[:veracity] }) if args[:veracity]
 
+      # Include these basics as they are part of most of queries for statements
+      # and seriously speed those queries
+      #
+      # TODO: When we have graphql-ruby 1.9+, lets use lookaheads for smart includes.
+      # See https://graphql-ruby.org/queries/lookahead.html
+      statements = statements.includes(
+        { assessment: :veracity },
+        { speaker: :body },
+        { source: :medium }
+      )
+
       statements
     }
   end

--- a/app/graphql/types/source_type.rb
+++ b/app/graphql/types/source_type.rb
@@ -6,11 +6,19 @@ Types::SourceType = GraphQL::ObjectType.define do
   field :id, !types.ID
   field :released_at, !types.String
   field :source_url, types.String
-  field :transcript, types.String
   field :medium, !Types::MediumType
   field :media_personalities, !types[!Types::MediaPersonalityType]
   field :speakers, !types[!Types::SpeakerType]
   field :expert, Types::UserType
+
+  field :transcript, types.String do
+    resolve ->(obj, args, ctx) {
+      # Transcript is mostly from Newton Media and cannot be offered publicly
+      raise Errors::AuthenticationNeededError.new unless ctx[:current_user]
+
+      obj.transcript
+    }
+  end
 
   field :name, !types.String do
     resolve ->(obj, args, ctx) {

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Membership < ApplicationRecord
-  scope :current, -> { find_by until: nil }
+  scope :current, -> { where(until: nil) }
 
   belongs_to :body
   belongs_to :speaker

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -2,6 +2,8 @@
 
 class Speaker < ApplicationRecord
   has_many :memberships, dependent: :destroy
+  has_one :current_membership, -> { current }, class_name: "Membership"
+  has_one :body, through: :current_membership
   has_many :bodies, through: :memberships
   has_many :statements
   has_many :assessments, through: :statements
@@ -38,16 +40,6 @@ class Speaker < ApplicationRecord
 
   def full_name
     "#{first_name} #{last_name}"
-  end
-
-  def body
-    current = memberships.current
-
-    if current.respond_to?(:body)
-      current.body
-    else
-      nil
-    end
   end
 
   def published_statements_by_veracity(veracity_id)

--- a/test/graphql/types/source_type/transcript_test.rb
+++ b/test/graphql/types/source_type/transcript_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "graphql/graphql_testcase"
+
+class SourceTypeTranscriptTest < GraphQLTestCase
+  test "Unauthenticated should not be able to access transcript" do
+    source = create(:source, transcript: "Lorem ipsum")
+
+    query_string = "
+      query {
+        source(id: #{source.id}) {
+          transcript
+        }
+      }"
+
+    result = execute_with_errors(query_string)
+
+    assert_auth_needed_error result
+  end
+
+  test "Authenticated should be able to access transcript" do
+    source = create(:source, transcript: "Lorem ipsum")
+
+    query_string = "
+      query {
+        source(id: #{source.id}) {
+          transcript
+        }
+      }"
+
+    result = execute(query_string, context: authenticated_user_context)
+
+    assert_equal "Lorem ipsum", result["data"]["source"]["transcript"]
+  end
+end


### PR DESCRIPTION
* Restrict source transcript for authenticated only (Fixes #351)
* Turn speaker.body into includable relation
* Add default includes to statements query to make it faster