### PR TITLE
Change TS target from ES5 to ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es5",
+    "target": "es6",
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
I changed the TS target to fix an issue with the CK editor that couldn't initialize our custom plugins, cause they were not "native" classes, but ES5 constructor functions.

If this change causes issues elsewhere, we'll revert back to ES5 and rewrite the plugins to pure functions.