### PR TITLE
Add (published and factual) statements search to the GraphQL API

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < FrontendController
 
     @articles = Article.query_search_published(@query)
     @speakers = Speaker.query_search(@query)
-    @statements = !@query.blank? ? StatementsElasticQueryService.search_published_factual(query: @query) : []
+    @statements = !@query.blank? ? StatementsElasticQueryService.search_published_factual({ query: @query }) : []
 
     unless @query.empty?
       SearchedQuery.create(

--- a/app/graphql/schema/search/resolvers/statement_search_result_resolver.rb
+++ b/app/graphql/schema/search/resolvers/statement_search_result_resolver.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Schema::Search::Resolvers
+  class StatementSearchResultResolver < GraphQL::Schema::Resolver
+    type Schema::Search::Types::SearchResultStatementType, null: false
+
+    argument :term, GraphQL::Types::String, required: true
+    argument :limit, GraphQL::Types::Int, required: false, default_value: 10
+    argument :offset, GraphQL::Types::Int, required: false, default_value: 0
+
+    def resolve(term:, limit:, offset:)
+      statement_search = StatementsElasticQueryService.search_published_factual({ query: term }, from: offset, size: limit)
+
+      { statements: statement_search.records.to_a, total_count: statement_search.total_count }
+    end
+  end
+end

--- a/app/graphql/schema/search/search_field.rb
+++ b/app/graphql/schema/search/search_field.rb
@@ -6,5 +6,6 @@ module Schema::Search::SearchField
   included do
     field :search_speakers, Schema::Search::Types::SearchResultSpeakerType, null: false, resolver: Schema::Search::Resolvers::SpeakerSearchResultResolver
     field :search_articles, Schema::Search::Types::SearchResultArticleType, null: false, resolver: Schema::Search::Resolvers::ArticleSearchResultResolver
+    field :search_statements, Schema::Search::Types::SearchResultStatementType, null: false, resolver: Schema::Search::Resolvers::StatementSearchResultResolver
   end
 end

--- a/app/graphql/schema/search/types/search_result_statement_type.rb
+++ b/app/graphql/schema/search/types/search_result_statement_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Schema::Search::Types
+  class SearchResultStatementType < Types::BaseObject
+    field :statements, [Types::StatementType], null: false
+    field :total_count, GraphQL::Types::Int, null: false
+  end
+end

--- a/app/services/statements_elastic_query_service.rb
+++ b/app/services/statements_elastic_query_service.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class StatementsElasticQueryService
-  def self.search_published_factual(filters)
-    Statement.search(
+  def self.search_published_factual(filters, **extra_params)
+    Statement.search({
       query: build_published_factual_elastic_query(filters),
       sort: [
         { 'source.released_at': { order: "desc" } }
       ],
       # Important as we have more than 10k statements (10k is the default size of elastic result window)
       track_total_hits: true
-    )
+    }.merge(extra_params))
   end
 
   def self.aggregate_published_factual(filters)

--- a/test/graphql/types/query_type/search_test.rb
+++ b/test/graphql/types/query_type/search_test.rb
@@ -4,7 +4,7 @@ require "graphql/graphql_testcase"
 
 class QueryTypeSearchTest < GraphQLTestCase
   def setup
-    elasticsearch_index [Speaker, Article]
+    elasticsearch_index [Speaker, Article, Statement]
   end
 
   test "search speakers" do
@@ -35,8 +35,6 @@ class QueryTypeSearchTest < GraphQLTestCase
   test "search articles" do
     article_one = create(:article, title: "Lorem ipsum")
     article_one.__elasticsearch__.index_document
-    # speaker_two = create(:speaker, first_name: "John", last_name: "Brown")
-    # speaker_two.__elasticsearch__.index_document
 
     article_one.__elasticsearch__.client.indices.refresh index: article_one.__elasticsearch__.index_name
 
@@ -57,7 +55,30 @@ class QueryTypeSearchTest < GraphQLTestCase
     assert_equal 1, result["data"]["searchArticles"]["totalCount"]
   end
 
+  test "search statements" do
+    statement_one = create(:statement, content: "Something he said and loads more")
+    statement_one.__elasticsearch__.index_document
+
+    statement_one.__elasticsearch__.client.indices.refresh index: statement_one.__elasticsearch__.index_name
+
+    query_string = <<~GRAPHQL
+      query {
+        searchStatements(term: "Something he said") {
+          statements {
+            id
+          }
+          totalCount
+        }
+      }
+    GRAPHQL
+
+    result = execute(query_string)
+
+    assert_equal [statement_one.id.to_s], result["data"]["searchStatements"]["statements"].pluck("id")
+    assert_equal 1, result["data"]["searchStatements"]["totalCount"]
+  end
+
   def teardown
-    elasticsearch_cleanup [Speaker, Article]
+    elasticsearch_cleanup [Speaker, Article, Statement]
   end
 end


### PR DESCRIPTION
It doesn't support all features yet, only the basic search. The extra features will be added in the follow-up.