### PR TITLE
Add public Demagog members to the GraphQL API

### DIFF
--- a/app/graphql/schema/members/members_field.rb
+++ b/app/graphql/schema/members/members_field.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Schema::Members::MembersField
+  extend ActiveSupport::Concern
+
+  included do
+    field :members, [Schema::Members::Types::MemberType], null: false
+
+    def members
+      User.public_members.ordered
+    end
+  end
+end

--- a/app/graphql/schema/members/types/member_type.rb
+++ b/app/graphql/schema/members/types/member_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Schema::Members::Types
+  class MemberType < Types::BaseObject
+    field :id, ID, null: false
+    field :full_name, String, null: false
+    field :position_description, String, null: true
+    field :bio, String, null: true
+    field :avatar, String, null: true
+
+    def avatar(size: nil)
+      return nil unless object.avatar.attached?
+
+      Rails.application.routes.url_helpers.rails_representation_url(object.avatar.variant(:thumbnail).processed, only_path: true)
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -13,6 +13,8 @@ class Types::QueryType < GraphQL::Schema::Object
   include Schema::Sources::SourceField
   include Schema::Sources::SourcesField
 
+  include Schema::Members::MembersField
+
   include Schema::Media::MediumField
   include Schema::Media::MediaField
   include Schema::Media::MediaPersonalityField

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,13 +8,18 @@ class User < ApplicationRecord
   default_scope { kept }
   scope :active, -> { where(active: true) }
 
+  scope :public_members, -> { where(active: true, user_public: true) }
+  scope :ordered, -> { order(rank: :asc, last_name: :asc) }
+
   has_and_belongs_to_many :roles, join_table: :users_roles
   has_many :comments
   has_many :assessments
   has_many :notifications, foreign_key: "recipient_id"
   has_and_belongs_to_many :sources, join_table: "sources_experts"
 
-  has_one_attached :avatar
+  has_one_attached :avatar do |attachable|
+    attachable.variant :thumbnail, resize: "114x114"
+  end
 
   delegate :authorized?, to: :role
 

--- a/test/factories/model_factory.rb
+++ b/test/factories/model_factory.rb
@@ -117,6 +117,13 @@ FactoryBot.define do
     trait :intern do
       role_id { Role.create_or_find_by(key: Role::INTERN, name: "Stážista").id }
     end
+
+    trait :with_avatar do
+      after :create do |user|
+        file_path = Rails.root.join("test", "fixtures", "files", "speaker.png")
+        user.avatar.attach(Rack::Test::UploadedFile.new(file_path, "image/png"))
+      end
+    end
   end
 
   factory :assessment do

--- a/test/graphql/schema/members/members_field_test.rb
+++ b/test/graphql/schema/members/members_field_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "graphql/graphql_testcase"
+
+class QueryTypeSpeakersTest < GraphQLTestCase
+  test "returns active team members sorted by rank" do
+      active_user_one = create(:user, user_public: true, position_description: "position_description 1", bio: "bio 1", rank: 2)
+      active_user_two = create(:user, :with_avatar, user_public: true, position_description: "position_description 2", bio: "bio 2", rank: 1)
+      create(:user, active: false)
+
+      query_string = "
+          query {
+            members {
+              id
+              fullName
+              positionDescription
+              bio
+              avatar
+            }
+          }
+        "
+
+      result = execute(query_string)
+      assert_equal 2, result["data"]["members"].size
+
+      assert_equal active_user_two.id, result.data.members[0].id.to_i
+      assert_equal active_user_two.full_name, result.data.members[0].fullName
+      assert_equal active_user_two.position_description, result.data.members[0].positionDescription
+      assert_equal active_user_two.bio, result.data.members[0].bio
+      assert_match(/speaker\.png/, result.data.members[0].avatar)
+
+      assert_equal active_user_one.id, result.data.members[1].id.to_i
+      assert_equal active_user_one.full_name, result.data.members[1].fullName
+      assert_equal active_user_one.position_description, result.data.members[1].positionDescription
+      assert_equal active_user_one.bio, result.data.members[1].bio
+    end
+end


### PR DESCRIPTION
Created new field instead of butchering the existing `users` field, which serves primarily for back office admin.